### PR TITLE
Add list_commands

### DIFF
--- a/examples/commands.ipynb
+++ b/examples/commands.ipynb
@@ -22,6 +22,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## List all commands"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "app.commands.list_commands()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Create a new console"
    ]
   },

--- a/ipylab/commands.py
+++ b/ipylab/commands.py
@@ -2,7 +2,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 from ipywidgets import Widget
-from traitlets import Unicode
+from traitlets import List, Unicode
 from ._frontend import module_name, module_version
 
 
@@ -11,9 +11,14 @@ class CommandRegistry(Widget):
     _model_module = Unicode(module_name).tag(sync=True)
     _model_module_version = Unicode(module_version).tag(sync=True)
 
+    _commands = List(Unicode, read_only=True).tag(sync=True)
+
     def execute(self, command, args=None):
         args = args or {}
         self.send({
             'func': 'execute',
             'payload': {'command': command, 'args': args}
         })
+
+    def list_commands(self):
+        return self._commands

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -194,6 +194,9 @@ export class CommandRegistryModel extends WidgetModel {
     this.commands = CommandRegistryModel._commands;
     super.initialize(attributes, options);
     this.on("msg:custom", this.onMessage.bind(this));
+
+    this.set('_commands', this.commands.listCommands());
+    this.save_changes();
   }
 
   private onMessage(msg: any) {


### PR DESCRIPTION
Fixes #4.

### Usage

```python
from ipylab import JupyterFrontEnd

app = JupyterFrontEnd()
app.commands.list_commands()
```

```
['__internal:context-menu-info',
 'apputils:activate-command-palette',
 'apputils:print',
...
]
```

![list_commands](https://user-images.githubusercontent.com/591645/69013935-82eb9900-0985-11ea-8a94-6e678c309424.gif)
