### PR TITLE
Add hook for ready event

### DIFF
--- a/examples/commands.ipynb
+++ b/examples/commands.ipynb
@@ -19,6 +19,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "app.version"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -85,6 +94,68 @@
    "outputs": [],
    "source": [
     "app.commands.execute('terminal:create-new')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Ready event\n",
+    "\n",
+    "Some functionalities might require the `JupyterFrontEnd` widget to be ready on the frontend first.\n",
+    "\n",
+    "This is for example the case when listing all the available commands, or retrieving the version with `app.version`.\n",
+    "\n",
+    "The `on_ready` method can be used to register a callback that will be fired when the frontend is ready."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ipylab import JupyterFrontEnd\n",
+    "from ipywidgets import Output\n",
+    "\n",
+    "app = JupyterFrontEnd()\n",
+    "out = Output()\n",
+    "\n",
+    "def init():\n",
+    "    # show the first 5 commands\n",
+    "    cmds = app.commands.list_commands()[:5]\n",
+    "    out.append_stdout(cmds)\n",
+    "\n",
+    "app.on_ready(init)\n",
+    "out"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or using `asyncio`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import asyncio\n",
+    "\n",
+    "app = JupyterFrontEnd()\n",
+    "\n",
+    "out = Output()\n",
+    "\n",
+    "async def init():\n",
+    "    await app.ready()\n",
+    "    cmds = app.commands.list_commands()[:5]\n",
+    "    out.append_stdout(cmds)\n",
+    "\n",
+    "asyncio.create_task(init())\n",
+    "out"
    ]
   }
  ],

--- a/ipylab/jupyterfrontend.py
+++ b/ipylab/jupyterfrontend.py
@@ -4,7 +4,9 @@
 # Copyright (c) Jeremy Tuloup.
 # Distributed under the terms of the Modified BSD License.
 
-from ipywidgets import Widget, widget_serialization
+import asyncio
+
+from ipywidgets import CallbackDispatcher, Widget, widget_serialization
 from traitlets import Instance, Unicode
 from ._frontend import module_name, module_version
 
@@ -13,15 +15,27 @@ from .shell import Shell
 
 
 class JupyterFrontEnd(Widget):
-    """TODO: Make Singleton?
-    """
-
     _model_name = Unicode("JupyterFrontEndModel").tag(sync=True)
     _model_module = Unicode(module_name).tag(sync=True)
     _model_module_version = Unicode(module_version).tag(sync=True)
 
+    version = Unicode(read_only=True).tag(sync=True)
     shell = Instance(Shell).tag(sync=True, **widget_serialization)
     commands = Instance(CommandRegistry).tag(sync=True, **widget_serialization)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, shell=Shell(), commands=CommandRegistry(), **kwargs)
+        self._ready_event = asyncio.Event()
+        self._on_ready_callbacks = CallbackDispatcher()
+        self.on_msg(self._on_frontend_msg)
+
+    def _on_frontend_msg(self, _, content, buffers):
+        if content.get("event", "") == "lab_ready":
+            self._ready_event.set()
+            self._on_ready_callbacks()
+
+    async def ready(self):
+        await self._ready_event.wait()
+
+    def on_ready(self, callback, remove=False):
+        self._on_ready_callbacks.register_callback(callback, remove)

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -237,8 +237,10 @@ export class JupyterFrontEndModel extends WidgetModel {
 
   initialize(attributes: any, options: any) {
     this.app = JupyterFrontEndModel._app;
-    console.log(this.app);
     super.initialize(attributes, options);
+    this.send({ event: 'lab_ready' }, {});
+    this.set('version', this.app.version);
+    this.save_changes();
   }
 
   static serializers: ISerializers = {


### PR DESCRIPTION
Fixes #9.

```python
app = JupyterFrontEnd()

def init():
    cmds = app.commands.list_commands()

app.on_ready(init)
```

For `asyncio`, this still requires spawning a separate task and doing the `await app.ready()` the coroutine:

```python
app = JupyterFrontEnd()

async def init():
    await app.ready()
    cmds = app.commands.list_commands()

asyncio.create_task(init())
```