### PR TITLE
Better support for left and right areas

### DIFF
--- a/css/widget.css
+++ b/css/widget.css
@@ -2,3 +2,26 @@
 .jp-JupyterPhosphorSplitPanelWidget .p-SplitPanel-handle {
   background-color: var(--jp-border-color2);
 }
+
+.jp-SideAreaWidget {
+  background: var(--jp-layout-color1);
+  display: flex;
+}
+
+.jp-SideBar.jp-mod-left .p-mod-closable .p-TabBar-tabCloseIcon,
+.jp-SideBar.jp-mod-right .p-mod-closable .p-TabBar-tabCloseIcon {
+  padding: 4px 0px 4px 4px;
+  background-size: 16px;
+  height: 16px;
+  width: 16px;
+  background-image: var(--jp-icon-close);
+  background-position: center;
+  background-repeat: no-repeat;
+  align-self: center;
+}
+
+.jp-SideBar.jp-mod-left .p-mod-closable .p-TabBar-tabCloseIcon:hover,
+.jp-SideBar.jp-mod-right .p-mod-closable .p-TabBar-tabCloseIcon:hover {
+  background-size: 16px;
+  background-image: var(--jp-icon-inverse-close-circle);
+}

--- a/examples/widgets.ipynb
+++ b/examples/widgets.ipynb
@@ -74,7 +74,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "split_panel.title.label = 'A Custom SplitPanel'"
+    "split_panel.title.label = 'A Custom SplitPanel'\n",
+    "split_panel.title.icon_class = 'jp-PythonIcon'"
    ]
   },
   {

--- a/examples/widgets.ipynb
+++ b/examples/widgets.ipynb
@@ -74,6 +74,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "split_panel.title.label = 'A Custom SplitPanel'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "app.shell.add(split_panel, 'main', { 'mode': 'split-bottom' })"
    ]
   },
@@ -93,6 +102,43 @@
    "outputs": [],
    "source": [
     "split_panel.addWidget(row_2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Left and Right Areas\n",
+    "\n",
+    "Add the same `SplitPanel` widget to the left area:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "app.shell.add(split_panel, 'left', { 'rank': '0' })\n",
+    "app.shell.expand_left()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And also to the right area:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "split_panel.title.closable = False\n",
+    "app.shell.add(split_panel, 'right', { 'rank': '1000' })\n",
+    "app.shell.expand_right()"
    ]
   }
  ],

--- a/examples/widgets.ipynb
+++ b/examples/widgets.ipynb
@@ -14,7 +14,7 @@
    "outputs": [],
    "source": [
     "from ipylab import JupyterFrontEnd, Panel, SplitPanel\n",
-    "from ipywidgets import IntSlider, Label, HBox\n",
+    "from ipywidgets import IntSlider, Label, VBox\n",
     "\n",
     "app = JupyterFrontEnd()"
    ]
@@ -60,9 +60,9 @@
    "outputs": [],
    "source": [
     "split_panel = SplitPanel()\n",
-    "row_2 = HBox([Label(\"Second Split\"), IntSlider()])\n",
+    "row_2 = VBox([Label(\"Second Split\"), IntSlider()])\n",
     "split_panel.children = [\n",
-    "    HBox([Label(\"First Split\"), IntSlider()]),\n",
+    "    VBox([Label(\"First Split\"), IntSlider()]),\n",
     "    row_2\n",
     "]\n",
     "split_panel"
@@ -74,8 +74,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "split_panel.title.label = 'A Custom SplitPanel'\n",
-    "split_panel.title.icon_class = 'jp-PythonIcon'"
+    "split_panel.title.label = 'A SplitPanel'\n",
+    "split_panel.title.icon_class = 'jp-PythonIcon'\n",
+    "split_panel.title.closable = True"
    ]
   },
   {

--- a/ipylab/shell.py
+++ b/ipylab/shell.py
@@ -24,3 +24,13 @@ class Shell(Widget):
                 },
             }
         )
+
+    def expand_left(self):
+        self.send(
+            {"func": "expandLeft", "payload": {},}
+        )
+
+    def expand_right(self):
+        self.send(
+            {"func": "expandRight", "payload": {},}
+        )

--- a/ipylab/widgets.py
+++ b/ipylab/widgets.py
@@ -12,6 +12,7 @@ class Title(Widget):
     _model_module_version = Unicode(module_version).tag(sync=True)
 
     label = Unicode().tag(sync=True)
+    icon_class = Unicode().tag(sync=True)
     closable = Bool(True).tag(sync=True)
 
 

--- a/ipylab/widgets.py
+++ b/ipylab/widgets.py
@@ -1,15 +1,29 @@
 # Copyright (c) Jeremy Tuloup.
 # Distributed under the terms of the Modified BSD License.
 
-from ipywidgets import VBox
-from traitlets import Unicode
+from ipywidgets import VBox, Widget, widget_serialization
+from traitlets import Bool, Instance, Unicode
 from ._frontend import module_name, module_version
+
+
+class Title(Widget):
+    _model_name = Unicode("TitleModel").tag(sync=True)
+    _model_module = Unicode(module_name).tag(sync=True)
+    _model_module_version = Unicode(module_version).tag(sync=True)
+
+    label = Unicode().tag(sync=True)
+    closable = Bool(True).tag(sync=True)
 
 
 class Panel(VBox):
     _model_name = Unicode("PanelModel").tag(sync=True)
     _model_module = Unicode(module_name).tag(sync=True)
     _model_module_version = Unicode(module_version).tag(sync=True)
+
+    title = Instance(Title).tag(sync=True, **widget_serialization)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, title=Title(), **kwargs)
 
 
 class SplitPanel(Panel):

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -3,7 +3,8 @@
 
 import {
   JupyterFrontEndPlugin,
-  JupyterFrontEnd
+  JupyterFrontEnd,
+  ILabShell
 } from '@jupyterlab/application';
 
 import { IJupyterWidgetRegistry } from '@jupyter-widgets/base';
@@ -17,11 +18,15 @@ const EXTENSION_ID = 'ipylab:plugin';
 const extension: JupyterFrontEndPlugin<void> = {
   id: EXTENSION_ID,
   autoStart: true,
-  requires: [IJupyterWidgetRegistry],
-  activate: (app: JupyterFrontEnd, registry: IJupyterWidgetRegistry): void => {
+  requires: [IJupyterWidgetRegistry, ILabShell],
+  activate: (
+    app: JupyterFrontEnd,
+    registry: IJupyterWidgetRegistry,
+    shell: ILabShell
+  ): void => {
     // add globals
     widgetExports.JupyterFrontEndModel._app = app;
-    widgetExports.ShellModel._shell = app.shell;
+    widgetExports.ShellModel._shell = shell;
     widgetExports.CommandRegistryModel._commands = app.commands;
 
     registry.registerWidget({

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -25,6 +25,24 @@ import $ from 'jquery';
 // Import the CSS
 import '../css/widget.css';
 
+export class TitleModel extends WidgetModel {
+  defaults() {
+    return {
+      ...super.defaults(),
+      _model_name: TitleModel.model_name,
+      _model_module: TitleModel.model_module,
+      _model_module_version: TitleModel.model_module_version
+    };
+  }
+
+  static model_name = 'TitleModel';
+  static model_module = MODULE_NAME;
+  static model_module_version = MODULE_VERSION;
+  static view_name: string = null;
+  static view_module: string = null;
+  static view_module_version = MODULE_VERSION;
+}
+
 export class PanelModel extends VBoxModel {
   defaults() {
     return {
@@ -152,10 +170,15 @@ export class ShellModel extends WidgetModel {
         );
         const view = await this.widget_manager.create_view(model, {});
 
+        const title = await unpack_models(
+          model.get('title'),
+          this.widget_manager
+        );
+
         let pWidget = view.pWidget;
         pWidget.id = view.id;
-        pWidget.title.label = 'Widget'; // TODO: read from widget
-        pWidget.title.closable = true;
+        pWidget.title.label = title.get('label');
+        pWidget.title.closable = title.get('closable');
         pWidget.disposed.connect(() => {
           view.remove();
         });

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -177,6 +177,12 @@ export class ShellModel extends WidgetModel {
         }
         this.shell.add(pWidget, area, args);
         break;
+      case 'expandLeft':
+        this.shell.expandLeft();
+        break;
+      case 'expandRight':
+        this.shell.expandRight();
+        break;
       default:
         break;
     }

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jeremy Tuloup
 // Distributed under the terms of the Modified BSD License.
 
-import { JupyterFrontEnd } from '@jupyterlab/application';
+import { JupyterFrontEnd, ILabShell } from '@jupyterlab/application';
 
 import { CommandRegistry } from '@phosphor/commands';
 
@@ -154,10 +154,27 @@ export class ShellModel extends WidgetModel {
 
         let pWidget = view.pWidget;
         pWidget.id = view.id;
+        pWidget.title.label = 'Widget'; // TODO: read from widget
         pWidget.title.closable = true;
         pWidget.disposed.connect(() => {
           view.remove();
         });
+
+        if (area === 'left' || area === 'right') {
+          let handler;
+          if (area === 'left') {
+            handler = this.shell['_leftHandler'];
+          } else {
+            handler = this.shell['_rightHandler'];
+          }
+
+          // handle tab closed event
+          handler.sideBar.tabCloseRequested.connect((sender: any, tab: any) => {
+            tab.title.owner.close();
+          });
+
+          pWidget.addClass('jp-SideAreaWidget');
+        }
         this.shell.add(pWidget, area, args);
         break;
       default:
@@ -176,8 +193,8 @@ export class ShellModel extends WidgetModel {
   static view_module: string = null;
   static view_module_version = MODULE_VERSION;
 
-  private shell: JupyterFrontEnd.IShell;
-  static _shell: JupyterFrontEnd.IShell;
+  private shell: ILabShell;
+  static _shell: ILabShell;
 }
 
 export class CommandRegistryModel extends WidgetModel {

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -177,12 +177,18 @@ export class ShellModel extends WidgetModel {
 
         let pWidget = view.pWidget;
         pWidget.id = view.id;
-        pWidget.title.label = title.get('label');
-        pWidget.title.iconClass = title.get('icon_class');
-        pWidget.title.closable = title.get('closable');
         pWidget.disposed.connect(() => {
           view.remove();
         });
+
+        const updateTitle = () => {
+          pWidget.title.label = title.get('label');
+          pWidget.title.iconClass = title.get('icon_class');
+          pWidget.title.closable = title.get('closable');
+        };
+
+        title.on('change', updateTitle);
+        updateTitle();
 
         if (area === 'left' || area === 'right') {
           let handler;

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -178,6 +178,7 @@ export class ShellModel extends WidgetModel {
         let pWidget = view.pWidget;
         pWidget.id = view.id;
         pWidget.title.label = title.get('label');
+        pWidget.title.iconClass = title.get('icon_class');
         pWidget.title.closable = title.get('closable');
         pWidget.disposed.connect(() => {
           view.remove();


### PR DESCRIPTION
Fixes #6.

### TODO

- [x] Switch to `ILabShell`
- [x] Default CSS for left and right areas
- [x] Create `Title` widget that `Panel` uses, so it's possible to configure the title, icon class and other parameters from Python
- [x] Expose `expandRight` and `expandLeft` methods on `shell`


![lelft-right-areas](https://user-images.githubusercontent.com/591645/69281298-54212d00-0be8-11ea-999b-ba33c1f6edd1.gif)
