### PR TITLE
Add custom Python commands to the palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,17 @@ Try it in your browser with Binder:
 
 ## Examples
 
+### Widgets and Panels
+
+![widgets-panels](https://user-images.githubusercontent.com/591645/69000410-8f151f00-08cf-11ea-8491-7b8848497b62.gif)
+
 ### Command Registry
 
 ![command-registry](./docs/screencasts/commands.gif)
 
-### Widgets and Panels
+### Custom Python Commands and Command Palette
 
-![widgets-panels](https://user-images.githubusercontent.com/591645/69000410-8f151f00-08cf-11ea-8491-7b8848497b62.gif)
+![custom-commands](https://user-images.githubusercontent.com/591645/73125753-adbc2400-3faa-11ea-95f8-f7060e883ccd.gif)
 
 ## Installation
 

--- a/examples/commands.ipynb
+++ b/examples/commands.ipynb
@@ -157,6 +157,77 @@
     "asyncio.create_task(init())\n",
     "out"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Add your own command"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from random import randint\n",
+    "from ipywidgets import IntSlider\n",
+    "\n",
+    "slider = IntSlider(min=0, max=100)\n",
+    "slider"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def my_command():\n",
+    "    slider.value = randint(0, 100)\n",
+    "\n",
+    "app.commands.add_command('random', execute=my_command, label=\"random\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Execute it!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "app.commands.execute('random')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The slider should now be moving and taking random values.\n",
+    "\n",
+    "That's great, but the command doesn't visually show up in the palette yet. So let's add it!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Add the command to the palette"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -175,7 +246,14 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.0"
+   "version": "3.8.1"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
   }
  },
  "nbformat": 4,

--- a/examples/commands.ipynb
+++ b/examples/commands.ipynb
@@ -187,7 +187,7 @@
     "def my_command():\n",
     "    slider.value = randint(0, 100)\n",
     "\n",
-    "app.commands.add_command('random', execute=my_command, label=\"random\")"
+    "app.commands.add_command('random', execute=my_command, label=\"My Random Command\")"
    ]
   },
   {
@@ -212,6 +212,22 @@
    "source": [
     "The slider should now be moving and taking random values.\n",
     "\n",
+    "Also the list of commands gets updated with the newly added command:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert 'random' in app.commands.list_commands()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "That's great, but the command doesn't visually show up in the palette yet. So let's add it!"
    ]
   },
@@ -227,7 +243,34 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "from ipylab.commands import CommandPalette"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "palette = CommandPalette()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "palette.add_item('random', 'Python Commands')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Open the command palette on the left side and the command should show now be visible."
+   ]
   }
  ],
  "metadata": {

--- a/examples/commands.ipynb
+++ b/examples/commands.ipynb
@@ -271,6 +271,24 @@
    "source": [
     "Open the command palette on the left side and the command should show now be visible."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Remove a command\n",
+    "\n",
+    "To remove a command that was previously added:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "app.commands.remove_command('random')"
+   ]
   }
  ],
  "metadata": {

--- a/ipylab/commands.py
+++ b/ipylab/commands.py
@@ -57,9 +57,8 @@ class CommandRegistry(Widget):
     def list_commands(self):
         return self._commands
 
-    # TODO: add support for also removing a command
     def add_command(self, command_id, execute, *, caption="", label="", icon_class=""):
-        if command_id in self._execute_callbacks or command_id in self._commands:
+        if command_id in self._commands:
             raise Exception(f"Command {command_id} is already registered")
         # TODO: support other parameters (isEnabled, isVisible...)
         self._execute_callbacks[command_id] = execute
@@ -74,3 +73,7 @@ class CommandRegistry(Widget):
                 },
             }
         )
+
+    def remove_command(self, command_id):
+        # TODO: check whether to keep this method, or return disposables like in lab
+        self.send({"func": "removeCommand", "payload": {"id": command_id}})

--- a/ipylab/commands.py
+++ b/ipylab/commands.py
@@ -1,8 +1,11 @@
 # Copyright (c) Jeremy Tuloup.
 # Distributed under the terms of the Modified BSD License.
 
-from ipywidgets import Widget
+from collections import defaultdict
+
+from ipywidgets import CallbackDispatcher, Widget
 from traitlets import List, Unicode
+
 from ._frontend import module_name, module_version
 
 
@@ -13,9 +16,36 @@ class CommandRegistry(Widget):
 
     _commands = List(Unicode, read_only=True).tag(sync=True)
 
-    def execute(self, command, args=None):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._execute_callbacks = defaultdict(CallbackDispatcher)
+        self.on_msg(self._on_frontend_msg)
+
+    def _on_frontend_msg(self, _, content, buffers):
+        if content.get("event", "") == "execute":
+            command_id = content.get("id")
+            self._execute_callbacks[command_id]()
+
+    def execute(self, command_id, args=None):
         args = args or {}
-        self.send({"func": "execute", "payload": {"command": command, "args": args}})
+        self.send({"func": "execute", "payload": {"id": command_id, "args": args}})
 
     def list_commands(self):
         return self._commands
+
+    def add_command(self, command_id, execute, *, caption="", label="", icon_class=""):
+        if command_id in self._execute_callbacks or command_id in self._commands:
+            raise Exception(f"Command {command_id} is already registered")
+        # TODO: support other parameters (isEnabled, isVisible...)
+        self._execute_callbacks[command_id].register_callback(execute, False)
+        self.send(
+            {
+                "func": "addCommand",
+                "payload": {
+                    "id": command_id,
+                    "caption": caption,
+                    "label": label,
+                    "iconClass": icon_class,
+                },
+            }
+        )

--- a/ipylab/commands.py
+++ b/ipylab/commands.py
@@ -9,16 +9,40 @@ from traitlets import List, Unicode
 from ._frontend import module_name, module_version
 
 
+def _noop():
+    pass
+
+
+class CommandPalette(Widget):
+    _model_name = Unicode("CommandPaletteModel").tag(sync=True)
+    _model_module = Unicode(module_name).tag(sync=True)
+    _model_module_version = Unicode(module_version).tag(sync=True)
+
+    def add_item(self, command_id, category, *, args=None, rank=None):
+        args = args or {}
+        self.send(
+            {
+                "func": "addItem",
+                "payload": {
+                    "id": command_id,
+                    "category": category,
+                    "args": args,
+                    "rank": rank,
+                },
+            }
+        )
+
+
 class CommandRegistry(Widget):
     _model_name = Unicode("CommandRegistryModel").tag(sync=True)
     _model_module = Unicode(module_name).tag(sync=True)
     _model_module_version = Unicode(module_version).tag(sync=True)
 
     _commands = List(Unicode, read_only=True).tag(sync=True)
+    _execute_callbacks = defaultdict(_noop)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._execute_callbacks = defaultdict(CallbackDispatcher)
         self.on_msg(self._on_frontend_msg)
 
     def _on_frontend_msg(self, _, content, buffers):
@@ -33,11 +57,12 @@ class CommandRegistry(Widget):
     def list_commands(self):
         return self._commands
 
+    # TODO: add support for also removing a command
     def add_command(self, command_id, execute, *, caption="", label="", icon_class=""):
         if command_id in self._execute_callbacks or command_id in self._commands:
             raise Exception(f"Command {command_id} is already registered")
         # TODO: support other parameters (isEnabled, isVisible...)
-        self._execute_callbacks[command_id].register_callback(execute, False)
+        self._execute_callbacks[command_id] = execute
         self.send(
             {
                 "func": "addCommand",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@jupyter-widgets/jupyterlab-manager": "^1.0.0",
     "@jupyterlab/application": "^1.2.0",
     "@jupyterlab/apputils": "^1.2.1",
+    "@jupyterlab/observables": "^2.4.0",
     "@phosphor/commands": "^1.7.2",
     "@phosphor/disposable": "1.3.1",
     "@phosphor/widgets": "^1.9.3"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,9 @@
     "@jupyter-widgets/controls": "^1.5.3",
     "@jupyter-widgets/jupyterlab-manager": "^1.0.0",
     "@jupyterlab/application": "^1.2.0",
+    "@jupyterlab/apputils": "^1.2.1",
     "@phosphor/commands": "^1.7.2",
+    "@phosphor/disposable": "1.3.1",
     "@phosphor/widgets": "^1.9.3"
   },
   "devDependencies": {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -7,6 +7,8 @@ import {
   ILabShell
 } from '@jupyterlab/application';
 
+import { ICommandPalette } from '@jupyterlab/apputils';
+
 import { IJupyterWidgetRegistry } from '@jupyter-widgets/base';
 
 import * as widgetExports from './widget';
@@ -19,15 +21,18 @@ const extension: JupyterFrontEndPlugin<void> = {
   id: EXTENSION_ID,
   autoStart: true,
   requires: [IJupyterWidgetRegistry, ILabShell],
+  optional: [ICommandPalette],
   activate: (
     app: JupyterFrontEnd,
     registry: IJupyterWidgetRegistry,
-    shell: ILabShell
+    shell: ILabShell,
+    palette: ICommandPalette
   ): void => {
     // add globals
     widgetExports.JupyterFrontEndModel._app = app;
     widgetExports.ShellModel._shell = shell;
     widgetExports.CommandRegistryModel._commands = app.commands;
+    widgetExports.CommandPaletteModel._palette = palette;
 
     registry.registerWidget({
       name: MODULE_NAME,

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -5,6 +5,7 @@
 import '../css/widget.css';
 
 import { CommandRegistryModel } from './widgets/commands';
+import { CommandPaletteModel } from './widgets/palette';
 import { JupyterFrontEndModel } from './widgets/frontend';
 import { PanelModel } from './widgets/panel';
 import { ShellModel } from './widgets/shell';
@@ -13,6 +14,7 @@ import { TitleModel } from './widgets/title';
 
 export {
   CommandRegistryModel,
+  CommandPaletteModel,
   JupyterFrontEndModel,
   PanelModel,
   ShellModel,

--- a/src/widgets/commands.ts
+++ b/src/widgets/commands.ts
@@ -20,21 +20,52 @@ export class CommandRegistryModel extends WidgetModel {
   initialize(attributes: any, options: any) {
     this.commands = CommandRegistryModel._commands;
     super.initialize(attributes, options);
-    this.on('msg:custom', this.onMessage.bind(this));
+    this.on('msg:custom', this._onMessage.bind(this));
 
     this.set('_commands', this.commands.listCommands());
     this.save_changes();
   }
 
-  private onMessage(msg: any) {
+  private _onMessage(msg: any) {
     switch (msg.func) {
       case 'execute':
-        const { command, args } = msg.payload;
-        void this.commands.execute(command, args);
+        this._execute(msg.payload);
+        break;
+      case 'addCommand':
+        void this._addComnand(msg.payload);
         break;
       default:
         break;
     }
+  }
+
+  private _execute(payload: any) {
+    const { id, args } = payload;
+    const name = `${id}-${this.model_id}`;
+    void this.commands.execute(name, args);
+  }
+
+  private async _addComnand(payload: any): Promise<void> {
+    // TODO: keep track of all the user commands,
+    // and dispose them all when the model is destroyed
+    const { id, caption, label, iconClass } = payload;
+    const name = `${id}-${this.model_id}`;
+    if (this.commands.hasCommand(name)) {
+      return;
+    }
+    void this.commands.addCommand(name, {
+      caption,
+      label,
+      iconClass,
+      execute: () => {
+        if (!this.comm_live) {
+          console.log('TODO: dispose the command');
+          return;
+        }
+        this.send({ event: 'execute', id }, {});
+      }
+    });
+    this.commands.notifyCommandChanged();
   }
 
   static serializers: ISerializers = {

--- a/src/widgets/palette.ts
+++ b/src/widgets/palette.ts
@@ -1,0 +1,62 @@
+// Copyright (c) Jeremy Tuloup
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  DOMWidgetModel,
+  ISerializers,
+  WidgetModel
+} from '@jupyter-widgets/base';
+
+import { MODULE_NAME, MODULE_VERSION } from '../version';
+import { ICommandPalette } from '@jupyterlab/apputils';
+
+export class CommandPaletteModel extends WidgetModel {
+  defaults() {
+    return {
+      ...super.defaults(),
+      _model_name: CommandPaletteModel.model_name,
+      _model_module: CommandPaletteModel.model_module,
+      _model_module_version: CommandPaletteModel.model_module_version
+    };
+  }
+
+  initialize(attributes: any, options: any) {
+    this.palette = CommandPaletteModel._palette;
+    super.initialize(attributes, options);
+
+    this.on('msg:custom', this._onMessage.bind(this));
+  }
+
+  private _onMessage(msg: any) {
+    switch (msg.func) {
+      case 'addItem':
+        this._addItem(msg.payload);
+        break;
+      default:
+        break;
+    }
+  }
+
+  private _addItem(payload: any) {
+    if (!this.palette) {
+      // no-op if no palette
+      return;
+    }
+    const { id, category, args, rank } = payload;
+    void this.palette.addItem({ command: id, category, args, rank });
+  }
+
+  static serializers: ISerializers = {
+    ...DOMWidgetModel.serializers
+  };
+
+  static model_name = 'CommandPaletteModel';
+  static model_module = MODULE_NAME;
+  static model_module_version = MODULE_VERSION;
+  static view_name: string = null;
+  static view_module: string = null;
+  static view_module_version = MODULE_VERSION;
+
+  private palette: ICommandPalette;
+  static _palette: ICommandPalette;
+}


### PR DESCRIPTION
Fixes #28.

Add support for custom Python commands and add them to the palette.

![command-palette](https://user-images.githubusercontent.com/591645/73125753-adbc2400-3faa-11ea-95f8-f7060e883ccd.gif)
