### PR TITLE
Update to the final packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,9 +59,9 @@
     ]
   },
   "dependencies": {
-    "@jupyter-widgets/base": "^1 || ^3.0.0-rc.0",
-    "@jupyter-widgets/controls": "^2.0.0-rc.12",
-    "@jupyter-widgets/jupyterlab-manager": "^2.0.0-rc.3",
+    "@jupyter-widgets/base": "^1 || ^2 || ^3",
+    "@jupyter-widgets/controls": "^2.0.0",
+    "@jupyter-widgets/jupyterlab-manager": "^2.0.0",
     "@jupyterlab/application": "^2.0.0",
     "@jupyterlab/apputils": "^2.0.0",
     "@jupyterlab/observables": "^3.0.0",


### PR DESCRIPTION
Use the latest published versions of the `@jupyter-widgets` packages.