### PR TITLE
Store widgets state to handle restore

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+    - name: TMP fix - install libgbm1
+      run: sudo apt install -y libgbm1
     - name: Checkout
       uses: actions/checkout@v1
     - name: Install node

--- a/ipylab/commands.py
+++ b/ipylab/commands.py
@@ -3,7 +3,7 @@
 
 from collections import defaultdict
 
-from ipywidgets import CallbackDispatcher, Widget
+from ipywidgets import CallbackDispatcher, Widget, register
 from traitlets import List, Unicode
 
 from ._frontend import module_name, module_version
@@ -13,6 +13,7 @@ def _noop():
     pass
 
 
+@register
 class CommandPalette(Widget):
     _model_name = Unicode("CommandPaletteModel").tag(sync=True)
     _model_module = Unicode(module_name).tag(sync=True)
@@ -35,6 +36,7 @@ class CommandPalette(Widget):
         )
 
 
+@register
 class CommandRegistry(Widget):
     _model_name = Unicode("CommandRegistryModel").tag(sync=True)
     _model_module = Unicode(module_name).tag(sync=True)

--- a/ipylab/commands.py
+++ b/ipylab/commands.py
@@ -18,6 +18,8 @@ class CommandPalette(Widget):
     _model_module = Unicode(module_name).tag(sync=True)
     _model_module_version = Unicode(module_version).tag(sync=True)
 
+    _items = List([], read_only=True).tag(sync=True)
+
     def add_item(self, command_id, category, *, args=None, rank=None):
         args = args or {}
         self.send(
@@ -38,7 +40,8 @@ class CommandRegistry(Widget):
     _model_module = Unicode(module_name).tag(sync=True)
     _model_module_version = Unicode(module_version).tag(sync=True)
 
-    _commands = List(Unicode, read_only=True).tag(sync=True)
+    _command_list = List(Unicode, read_only=True).tag(sync=True)
+    _commands = List([], read_only=True).tag(sync=True)
     _execute_callbacks = defaultdict(_noop)
 
     def __init__(self, *args, **kwargs):
@@ -55,10 +58,10 @@ class CommandRegistry(Widget):
         self.send({"func": "execute", "payload": {"id": command_id, "args": args}})
 
     def list_commands(self):
-        return self._commands
+        return self._command_list
 
     def add_command(self, command_id, execute, *, caption="", label="", icon_class=""):
-        if command_id in self._commands:
+        if command_id in self._command_list:
             raise Exception(f"Command {command_id} is already registered")
         # TODO: support other parameters (isEnabled, isVisible...)
         self._execute_callbacks[command_id] = execute

--- a/ipylab/jupyterfrontend.py
+++ b/ipylab/jupyterfrontend.py
@@ -6,7 +6,7 @@
 
 import asyncio
 
-from ipywidgets import CallbackDispatcher, Widget, widget_serialization
+from ipywidgets import CallbackDispatcher, Widget, register, widget_serialization
 from traitlets import Instance, Unicode
 from ._frontend import module_name, module_version
 
@@ -14,6 +14,7 @@ from .commands import CommandRegistry
 from .shell import Shell
 
 
+@register
 class JupyterFrontEnd(Widget):
     _model_name = Unicode("JupyterFrontEndModel").tag(sync=True)
     _model_module = Unicode(module_name).tag(sync=True)

--- a/ipylab/shell.py
+++ b/ipylab/shell.py
@@ -1,11 +1,12 @@
 # Copyright (c) Jeremy Tuloup.
 # Distributed under the terms of the Modified BSD License.
 
-from ipywidgets import Widget, widget_serialization
+from ipywidgets import Widget, register, widget_serialization
 from traitlets import List, Unicode
 from ._frontend import module_name, module_version
 
 
+@register
 class Shell(Widget):
     _model_name = Unicode("ShellModel").tag(sync=True)
     _model_module = Unicode(module_name).tag(sync=True)

--- a/ipylab/shell.py
+++ b/ipylab/shell.py
@@ -2,7 +2,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 from ipywidgets import Widget, widget_serialization
-from traitlets import Unicode
+from traitlets import List, Unicode
 from ._frontend import module_name, module_version
 
 
@@ -10,6 +10,8 @@ class Shell(Widget):
     _model_name = Unicode("ShellModel").tag(sync=True)
     _model_module = Unicode(module_name).tag(sync=True)
     _model_module_version = Unicode(module_version).tag(sync=True)
+
+    _widgets = List([], read_only=True).tag(sync=True)
 
     def add(self, widget, area, args=None):
         args = args or {}

--- a/ipylab/widgets.py
+++ b/ipylab/widgets.py
@@ -1,11 +1,12 @@
 # Copyright (c) Jeremy Tuloup.
 # Distributed under the terms of the Modified BSD License.
 
-from ipywidgets import VBox, Widget, widget_serialization
+from ipywidgets import VBox, Widget, register, widget_serialization
 from traitlets import Bool, Instance, Unicode
 from ._frontend import module_name, module_version
 
 
+@register
 class Title(Widget):
     _model_name = Unicode("TitleModel").tag(sync=True)
     _model_module = Unicode(module_name).tag(sync=True)
@@ -16,6 +17,7 @@ class Title(Widget):
     closable = Bool(True).tag(sync=True)
 
 
+@register
 class Panel(VBox):
     _model_name = Unicode("PanelModel").tag(sync=True)
     _model_module = Unicode(module_name).tag(sync=True)
@@ -27,6 +29,7 @@ class Panel(VBox):
         super().__init__(*args, title=Title(), **kwargs)
 
 
+@register
 class SplitPanel(Panel):
     _model_name = Unicode("SplitPanelModel").tag(sync=True)
     _model_module = Unicode(module_name).tag(sync=True)

--- a/package.json
+++ b/package.json
@@ -65,8 +65,10 @@
     "@jupyterlab/application": "^2.0.0",
     "@jupyterlab/apputils": "^2.0.0",
     "@jupyterlab/observables": "^3.0.0",
+    "@lumino/algorithm": "^1.2.3",
     "@lumino/commands": "^1.10.1",
     "@lumino/disposable": "^1.3.5",
+    "@lumino/messaging": "^1.3.3",
     "@lumino/widgets": "^1.11.1"
   },
   "devDependencies": {

--- a/src/widgets/palette.ts
+++ b/src/widgets/palette.ts
@@ -3,11 +3,15 @@
 
 import { ICommandPalette, IPaletteItem } from '@jupyterlab/apputils';
 
+import { ObservableMap } from '@jupyterlab/observables';
+
 import {
   DOMWidgetModel,
   ISerializers,
   WidgetModel,
 } from '@jupyter-widgets/base';
+
+import { IDisposable } from '@lumino/disposable';
 
 import { MODULE_NAME, MODULE_VERSION } from '../version';
 
@@ -76,7 +80,13 @@ export class CommandPaletteModel extends WidgetModel {
       return;
     }
     const { id, category, args, rank } = options;
-    void this._palette.addItem({ command: id, category, args, rank });
+    const itemId = `${id}-${category}`;
+    if (Private.customItems.has(itemId)) {
+      // no-op if the item is already in the palette
+      return;
+    }
+    const item = this._palette.addItem({ command: id, category, args, rank });
+    Private.customItems.set(itemId, item);
   }
 
   static serializers: ISerializers = {
@@ -93,4 +103,11 @@ export class CommandPaletteModel extends WidgetModel {
   private _palette: ICommandPalette;
 
   static palette: ICommandPalette;
+}
+
+/**
+ * A namespace for private data
+ */
+namespace Private {
+  export const customItems = new ObservableMap<IDisposable>();
 }

--- a/src/widgets/palette.ts
+++ b/src/widgets/palette.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Jeremy Tuloup
 // Distributed under the terms of the Modified BSD License.
 
+import { ICommandPalette, IPaletteItem } from '@jupyterlab/apputils';
+
 import {
   DOMWidgetModel,
   ISerializers,
@@ -8,7 +10,6 @@ import {
 } from '@jupyter-widgets/base';
 
 import { MODULE_NAME, MODULE_VERSION } from '../version';
-import { ICommandPalette, IPaletteItem } from '@jupyterlab/apputils';
 
 /**
  * The model for a command palette.
@@ -23,6 +24,7 @@ export class CommandPaletteModel extends WidgetModel {
       _model_name: CommandPaletteModel.model_name,
       _model_module: CommandPaletteModel.model_module,
       _model_module_version: CommandPaletteModel.model_module_version,
+      _items: [],
     };
   }
 
@@ -37,6 +39,10 @@ export class CommandPaletteModel extends WidgetModel {
     super.initialize(attributes, options);
 
     this.on('msg:custom', this._onMessage.bind(this));
+
+    // restore existing items
+    const items = this.get('_items');
+    items.forEach((item: any) => this._addItem(item));
   }
 
   /**
@@ -46,9 +52,14 @@ export class CommandPaletteModel extends WidgetModel {
    */
   private _onMessage(msg: any): void {
     switch (msg.func) {
-      case 'addItem':
+      case 'addItem': {
         this._addItem(msg.payload);
+        // keep track of the items
+        const items = this.get('_items');
+        this.set('_items', items.concat(msg.payload));
+        this.save_changes();
         break;
+      }
       default:
         break;
     }

--- a/src/widgets/shell.ts
+++ b/src/widgets/shell.ts
@@ -50,19 +50,6 @@ export class ShellModel extends WidgetModel {
     widgets.forEach((w: any) => this._add(w));
   }
 
-  private _hook(sender: any, msg: Message): boolean {
-    switch (msg.type) {
-      case 'close-request': {
-        const widgets = this.get('_widgets').slice();
-        ArrayExt.removeAllWhere(widgets, (w: any) => w.id === sender.id);
-        this.set('_widgets', widgets);
-        this.save_changes();
-        break;
-      }
-    }
-    return true;
-  }
-
   /**
    * Add a widget to the application shell
    *
@@ -77,7 +64,18 @@ export class ShellModel extends WidgetModel {
 
     pWidget.id = id ?? DOMUtils.createDomID();
 
-    MessageLoop.installMessageHook(pWidget, this._hook.bind(this));
+    MessageLoop.installMessageHook(pWidget, (handler: any, msg: Message) => {
+      switch (msg.type) {
+        case 'close-request': {
+          const widgets = this.get('_widgets').slice();
+          ArrayExt.removeAllWhere(widgets, (w: any) => w.id === handler.id);
+          this.set('_widgets', widgets);
+          this.save_changes();
+          break;
+        }
+      }
+      return true;
+    });
 
     const updateTitle = (): void => {
       pWidget.title.label = title.get('label');


### PR DESCRIPTION
Partial fix for #8.

![restore-widgets](https://user-images.githubusercontent.com/591645/79641355-4cfe4b00-8197-11ea-9645-ebc569e3ef4f.gif)

Handle a simple restore by storing the Lumino widgets in the state of the Jupyter widget, and re-adding them to the shell on `initialize`.

The restore process might not be optimal yet:

- interactions with the dock panel like are not persisted (only if the widget is removed)
- the source notebook still needs to be opened to restore the associated widgets

But at least it (partially) restores some of it (best effort) as part of the Jupyter widget state restoration. 

Commands and palette are now also restored using the same approach (storing them in the widget state).