### PR TITLE
Fix packaging CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install jupyter_packaging
-        python -m pip install --pre jupyterlab
+        python -m pip install jupyterlab
     - name: Install the ipylab Python package and JupyterLab extension
       run: |
         python -m pip install .

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -80,7 +80,11 @@ jobs:
           path: ./dist
       - name: Install the prerequisites
         run: |
-          ${{ matrix.py_cmd }} -m pip install pip wheel
+          ${{ matrix.py_cmd }} -m pip install --upgrade pip
+          ${{ matrix.py_cmd }} -m pip install jupyter-packaging==0.7.9
+      - name: TMP
+        run: |
+          ls -lisah dist
       - name: Install the package
         run: |
           cd dist


### PR DESCRIPTION
It looks like the CI workflow to check packaging is correct should have failed in: https://github.com/jtpio/ipylab/pull/51

Because of:

https://github.com/jtpio/ipylab/blob/3092b89f4e69902b60d8a8c3ad43279699271459/setup.py#L39-L41

