### PR TITLE
Update to ipytree 0.2 on Binder

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
 - bqplot=0.12
 - ipylab=0.4.1
-- ipytree=0.1
+- ipytree=0.2
 - jupyterlab=3
 - nodejs
 - numpy


### PR DESCRIPTION
The `0.2` release adds support for JupyterLab 3.0