### PR TITLE
Automated Changelog Entry for 0.5.0 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,42 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.5.0
+
+([Full Changelog](https://github.com/jtpio/ipylab/compare/0.4.1...1c614527d2647906a2d1e91c71b698b72ae6643b))
+
+### Maintenance and upkeep improvements
+
+- Update dependencies [#74](https://github.com/jtpio/ipylab/pull/74) ([@jtpio](https://github.com/jtpio))
+- Adopt the Jupyter Releaser [#73](https://github.com/jtpio/ipylab/pull/73) ([@jtpio](https://github.com/jtpio))
+- Add a Binder on PR workflow [#72](https://github.com/jtpio/ipylab/pull/72) ([@jtpio](https://github.com/jtpio))
+- Re-enable the Windows install check on 3.6 [#71](https://github.com/jtpio/ipylab/pull/71) ([@jtpio](https://github.com/jtpio))
+- Update to Jupyter Packaging 0.10 [#69](https://github.com/jtpio/ipylab/pull/69) ([@jtpio](https://github.com/jtpio))
+
+### Other merged PRs
+
+- Bump tar from 6.1.5 to 6.1.11 [#68](https://github.com/jtpio/ipylab/pull/68) ([@dependabot](https://github.com/dependabot))
+- Bump path-parse from 1.0.6 to 1.0.7 [#67](https://github.com/jtpio/ipylab/pull/67) ([@dependabot](https://github.com/dependabot))
+- Bump tar from 6.1.0 to 6.1.5 [#66](https://github.com/jtpio/ipylab/pull/66) ([@dependabot](https://github.com/dependabot))
+- Bump ws from 7.4.4 to 7.5.0 [#64](https://github.com/jtpio/ipylab/pull/64) ([@dependabot](https://github.com/dependabot))
+- Run CI on node 12 [#63](https://github.com/jtpio/ipylab/pull/63) ([@jtpio](https://github.com/jtpio))
+- Include the style/style.js file in the package [#62](https://github.com/jtpio/ipylab/pull/62) ([@vidartf](https://github.com/vidartf))
+- Bump postcss from 7.0.35 to 7.0.36 [#61](https://github.com/jtpio/ipylab/pull/61) ([@dependabot](https://github.com/dependabot))
+- Bump normalize-url from 4.5.0 to 4.5.1 [#60](https://github.com/jtpio/ipylab/pull/60) ([@dependabot](https://github.com/dependabot))
+- Bump browserslist from 4.16.3 to 4.16.6 [#58](https://github.com/jtpio/ipylab/pull/58) ([@dependabot](https://github.com/dependabot))
+- Bump hosted-git-info from 2.8.8 to 2.8.9 [#57](https://github.com/jtpio/ipylab/pull/57) ([@dependabot](https://github.com/dependabot))
+- Update to ipytree 0.2 on Binder [#56](https://github.com/jtpio/ipylab/pull/56) ([@jtpio](https://github.com/jtpio))
+- Update dependencies [#55](https://github.com/jtpio/ipylab/pull/55) ([@jtpio](https://github.com/jtpio))
+- Rename master -> main on CI [#54](https://github.com/jtpio/ipylab/pull/54) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jtpio/ipylab/graphs/contributors?from=2021-01-12&to=2021-09-06&type=c))
+
+[@dependabot](https://github.com/search?q=repo%3Ajtpio%2Fipylab+involves%3Adependabot+updated%3A2021-01-12..2021-09-06&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajtpio%2Fipylab+involves%3Agithub-actions+updated%3A2021-01-12..2021-09-06&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajtpio%2Fipylab+involves%3Ajtpio+updated%3A2021-01-12..2021-09-06&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Ajtpio%2Fipylab+involves%3Avidartf+updated%3A2021-01-12..2021-09-06&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.4.1
 
 - Fix jstargets in setup.py: https://github.com/jtpio/ipylab/pull/53
-
-<!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.5.0 on main
Python version: 0.5.0
npm version: ipylab: 0.4.1

After merging this PR run the "Draft Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jtpio/ipylab  |
| Branch  | main  |
| Version Spec | 0.5.0 |
| Since | 0.4.1 |