### PR TITLE
Add icons for titles and commands

### DIFF
--- a/examples/commands.ipynb
+++ b/examples/commands.ipynb
@@ -236,7 +236,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This function will now be called when the JupyterLab command is executed."
+    "This function will now be called when the JupyterLab command is executed.\n",
+    "\n",
+    "> Commands can also custom [icons](./icons.ipynb) in place of `icon_class`."
    ]
   },
   {
@@ -245,7 +247,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "app.commands.add_command('update_data', execute=update_data, label=\"Update Data\")"
+    "app.commands.add_command('update_data', execute=update_data, label=\"Update Data\", icon_class=\"jp-PythonIcon\")"
    ]
   },
   {
@@ -351,7 +353,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -365,7 +367,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.11.0"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/examples/icons.ipynb
+++ b/examples/icons.ipynb
@@ -1,0 +1,256 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "690da69f-cf3d-40a9-b8e0-610339c859e9",
+   "metadata": {},
+   "source": [
+    "# Icons"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5267848-fde6-4108-b7ff-be9e7303d0e4",
+   "metadata": {},
+   "source": [
+    "Icons can be applied to both the `Title` of a `Panel` [widgets](./widgets.ipynb) and [commands](./commands.ipynb), providing more customization than `icon_class`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b18ff57-b458-4b92-bbf3-0e660343d067",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from ipylab import Icon"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5a05db60-7147-4466-b8e3-296e59204013",
+   "metadata": {},
+   "source": [
+    "## SVG\n",
+    "\n",
+    "An icon requires both a _unique_ name, as well as an SVG string. There are some [guidelines](https://jupyterlab.readthedocs.io/en/stable/extension/ui_components.html#labicon-set-up-and-render-icons) for creating \"good\" icons. For example:\n",
+    "- don't include the `<?xml>` declaration\n",
+    "- don't use `ids`\n",
+    "- don't specify a `width` or `height`\n",
+    "  - ensures the icon can be used in a number of settings\n",
+    "- use the `jp-icon*` classes on filled items\n",
+    "  - ensures the icon looks good on light and dark themes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a02c39d9-1284-4f84-b13f-d7028640c821",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "SVG = \"\"\"<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\">\n",
+    "  <circle class=\"jp-icon-selectable jp-icon3\" cx=\"12\" cy=\"12\" r=\"12\" fill=\"#616161\" />\n",
+    "  <path class=\"jp-contrast0\" fill=\"#fff\" d=\"M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z\"/>\n",
+    "</svg>\"\"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22c3c5a5-ae3c-435c-9f12-21e247cf80f3",
+   "metadata": {},
+   "source": [
+    "Icons can be displayed directly, and sized with the `layout` member inherited from `ipywidgets.DOMWidget`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "add039d5-35d7-44ee-a70e-7d9cf38f56eb",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "icon = Icon(name=\"my-icon\", svgstr=SVG, layout=dict(width=\"32px\"))\n",
+    "icon"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2555a92e-3335-407d-8e8e-22d686794913",
+   "metadata": {},
+   "source": [
+    "### More about `jp-icon` classes\n",
+    "The interactive below isn't particuarly _robust_, but shows how the different `jp-icon-*` classes can be used."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ccea8868-2d3e-454d-b3d5-15e16cf51f54",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from ipylab import Panel, JupyterFrontEnd\n",
+    "from ipywidgets import SelectionSlider, FloatSlider, VBox\n",
+    "from traitlets import dlink, link\n",
+    "\n",
+    "icon_prefix = [\"\", \"-accent\", \"-brand\", \"-contrast\", \"-warn\"]\n",
+    "options = [\"\"] + [f\"jp-icon{sub}{i}\" for sub in icon_prefix for i in range(5)]\n",
+    "background = SelectionSlider(description=\"background\", options=options)\n",
+    "foreground = SelectionSlider(description=\"foreground\", options=options)\n",
+    "\n",
+    "repaint = lambda: SVG.replace(\"jp-icon3\", background.value).replace(\"jp-contrast0\", foreground.value)\n",
+    "\n",
+    "dlink((background, \"value\"), (icon, \"svgstr\"), lambda x: SVG.replace(\"jp-icon3\", x))\n",
+    "dlink((foreground, \"value\"), (icon, \"svgstr\"), lambda x: SVG.replace(\"jp-contrast0\", x))\n",
+    "size = FloatSlider(32, description=\"size\")\n",
+    "dlink((size, \"value\"), (icon.layout, \"width\"), \"{}px\".format)\n",
+    "icon_controls = VBox([background, foreground, size, icon])\n",
+    "icon_controls"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5f0a6742-3a3b-4879-8bb0-e675c80f03ed",
+   "metadata": {},
+   "source": [
+    "## Icons on Panel Titles\n",
+    "\n",
+    "Once defined, an icon can be used on a panel title in place of `icon_class` "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29a7cd8c-e26b-4a54-aca5-ae19fab2772d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "app = JupyterFrontEnd()\n",
+    "panel = Panel([icon_controls])\n",
+    "panel.title.icon = icon\n",
+    "dlink((background, \"value\"), (panel.title, \"label\"))\n",
+    "app.shell.add(panel, \"main\", {\"mode\": \"split-right\"})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3018262-e383-4b8e-b0cb-b8cefd936d98",
+   "metadata": {},
+   "source": [
+    "## Icons on Commands\n",
+    "\n",
+    "Icons can also assigned to [commands](./commands.ipynb) to provide additional context. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "386a1149-26f9-4def-9eab-146baaebfdb3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import asyncio\n",
+    "import random\n",
+    "\n",
+    "async def randomize_icon():\n",
+    "    for i in range(10):\n",
+    "        background.value = random.choice(options)\n",
+    "        await asyncio.sleep(0.1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5b16eaad-69e2-436c-a99a-d9e299977973",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "app.commands.add_command(\n",
+    "    \"my-icon:randomize\",\n",
+    "    lambda: asyncio.get_running_loop().create_task(randomize_icon()),\n",
+    "    label=\"Randomize My Icon\",\n",
+    "    icon=icon\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dc396794-ee61-4af4-aac3-d303321eb04a",
+   "metadata": {},
+   "source": [
+    "To see these, add the a _Command Palette_ with the same `command_id`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "82b36a75-235f-4ac1-92a5-b79131b480f1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from ipylab.commands import CommandPalette\n",
+    "\n",
+    "palette = CommandPalette()\n",
+    "palette.add_item(\"my-icon:randomize\", \"All My Commands\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4d961ace-35da-4965-b529-703b69ce828b",
+   "metadata": {},
+   "source": [
+    "Then open the _Command Palette_."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0bcbb157-6741-446a-a04b-de8ad2dda74a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "app.commands.execute(\"apputils:activate-command-palette\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/widgets.ipynb
+++ b/examples/widgets.ipynb
@@ -161,6 +161,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> As an alternative to `icon_class`, a `Panel` can also use custom [icons](./icons.ipynb)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -281,7 +288,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -295,7 +302,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.11.0"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/ipylab/__init__.py
+++ b/ipylab/__init__.py
@@ -11,7 +11,8 @@ from pathlib import Path
 from ._version import __version__, version_info
 
 from .jupyterfrontend import JupyterFrontEnd
-from .widgets import Panel, SplitPanel
+from .widgets import Panel, SplitPanel, Icon
+from .icon import Icon
 
 HERE = Path(__file__).parent.resolve()
 

--- a/ipylab/commands.py
+++ b/ipylab/commands.py
@@ -62,7 +62,9 @@ class CommandRegistry(Widget):
     def list_commands(self):
         return self._command_list
 
-    def add_command(self, command_id, execute, *, caption="", label="", icon_class=""):
+    def add_command(
+        self, command_id, execute, *, caption="", label="", icon_class="", icon=None
+    ):
         if command_id in self._command_list:
             raise Exception(f"Command {command_id} is already registered")
         # TODO: support other parameters (isEnabled, isVisible...)
@@ -75,6 +77,7 @@ class CommandRegistry(Widget):
                     "caption": caption,
                     "label": label,
                     "iconClass": icon_class,
+                    "icon": f"IPY_MODEL_{icon.model_id}" if icon else None,
                 },
             }
         )

--- a/ipylab/icon.py
+++ b/ipylab/icon.py
@@ -1,0 +1,19 @@
+# Copyright (c) ipylab contributors.
+# Distributed under the terms of the Modified BSD License.
+
+from ipywidgets import DOMWidget, register
+from traitlets import Unicode, Float
+from ._version import module_name, module_version
+
+
+@register
+class Icon(DOMWidget):
+    _model_name = Unicode("IconModel").tag(sync=True)
+    _model_module = Unicode(module_name).tag(sync=True)
+    _model_module_version = Unicode(module_version).tag(sync=True)
+    _view_name = Unicode("IconView").tag(sync=True)
+    _view_module = Unicode(module_name).tag(sync=True)
+    _view_module_version = Unicode(module_version).tag(sync=True)
+
+    name = Unicode().tag(sync=True)
+    svgstr = Unicode().tag(sync=True)

--- a/ipylab/widgets.py
+++ b/ipylab/widgets.py
@@ -4,6 +4,7 @@
 from ipywidgets import VBox, Widget, register, widget_serialization
 from traitlets import Bool, Instance, Unicode
 from ._version import module_name, module_version
+from .icon import Icon
 
 
 @register
@@ -15,6 +16,7 @@ class Title(Widget):
     label = Unicode().tag(sync=True)
     icon_class = Unicode().tag(sync=True)
     closable = Bool(True).tag(sync=True)
+    icon = Instance(Icon, allow_none=True).tag(sync=True, **widget_serialization)
 
 
 @register

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "prettier": "prettier --write \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}\" \"!dist/**\" \"!docs/**\"",
     "prettier:check": "prettier --list-different \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}\" \"!dist/**\" \"!docs/**\"",
     "watch": "npm-run-all -p watch:*",
-    "watch:lib": "tsc -w"
+    "watch:lib": "tsc -w",
+    "watch:labextension": "jupyter labextension watch ."
   },
   "husky": {
     "hooks": {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -11,8 +11,6 @@ import { ICommandPalette } from '@jupyterlab/apputils';
 
 import { IJupyterWidgetRegistry } from '@jupyter-widgets/base';
 
-import * as widgetExports from './widget';
-
 import { MODULE_NAME, MODULE_VERSION } from './version';
 
 const EXTENSION_ID = 'ipylab:plugin';
@@ -31,20 +29,25 @@ const extension: JupyterFrontEndPlugin<void> = {
     palette: ICommandPalette,
     labShell: ILabShell | null
   ): void => {
-    // add globals
-    widgetExports.JupyterFrontEndModel.app = app;
-    widgetExports.ShellModel.shell = app.shell;
-    widgetExports.ShellModel.labShell = labShell;
-    widgetExports.CommandRegistryModel.commands = app.commands;
-    widgetExports.CommandPaletteModel.palette = palette;
-    widgetExports.SessionManagerModel.sessions = app.serviceManager.sessions;
-    widgetExports.SessionManagerModel.shell = app.shell;
-    widgetExports.SessionManagerModel.labShell = labShell;
-
     registry.registerWidget({
       name: MODULE_NAME,
       version: MODULE_VERSION,
-      exports: widgetExports,
+      exports: async () => {
+        const widgetExports = await import('./widget');
+
+        // add globals
+        widgetExports.JupyterFrontEndModel.app = app;
+        widgetExports.ShellModel.shell = app.shell;
+        widgetExports.ShellModel.labShell = labShell;
+        widgetExports.CommandRegistryModel.commands = app.commands;
+        widgetExports.CommandPaletteModel.palette = palette;
+        widgetExports.SessionManagerModel.sessions =
+          app.serviceManager.sessions;
+        widgetExports.SessionManagerModel.shell = app.shell;
+        widgetExports.SessionManagerModel.labShell = labShell;
+
+        return widgetExports;
+      },
     });
   },
 };

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -9,6 +9,7 @@ import { PanelModel } from './widgets/panel';
 import { ShellModel } from './widgets/shell';
 import { SplitPanelModel, SplitPanelView } from './widgets/split_panel';
 import { TitleModel } from './widgets/title';
+import { IconView, IconModel } from './widgets/icon';
 
 export {
   CommandRegistryModel,
@@ -20,4 +21,6 @@ export {
   SplitPanelView,
   TitleModel,
   SessionManagerModel,
+  IconModel,
+  IconView,
 };

--- a/src/widgets/icon.ts
+++ b/src/widgets/icon.ts
@@ -1,0 +1,87 @@
+// Copyright (c) ipylab contributors
+// Distributed under the terms of the Modified BSD License.
+
+import { LabIcon } from '@jupyterlab/ui-components';
+
+import { DOMWidgetView, DOMWidgetModel } from '@jupyter-widgets/base';
+
+import { MODULE_NAME, MODULE_VERSION } from '../version';
+
+export class IconView extends DOMWidgetView {
+  initialize(parameters: any) {
+    super.initialize(parameters);
+    this.iconElement = document.createElement('div');
+    this.el.appendChild(this.iconElement);
+    this.update();
+  }
+
+  update() {
+    const { labIcon } = this.model;
+    if (labIcon) {
+      labIcon.render(this.iconElement, {
+        props: { tag: 'div' },
+      });
+    }
+  }
+
+  model: IconModel;
+  protected iconElement: HTMLElement;
+}
+
+/**
+ * The model for a title widget.
+ */
+export class IconModel extends DOMWidgetModel {
+  /**
+   * The default attributes.
+   */
+  defaults(): any {
+    return {
+      ...super.defaults(),
+      _model_name: IconModel.model_name,
+      _model_module: IconModel.model_module,
+      _model_module_version: IconModel.model_module_version,
+      _view_name: IconModel.view_name,
+      _view_module: IconModel.view_module,
+      _view_module_version: IconModel.view_module_version,
+    };
+  }
+
+  /**
+   * Initialize a LabIcon instance.
+   *
+   * @param attributes The base attributes.
+   * @param options The initialization options.
+   */
+  initialize(attributes: any, options: any): void {
+    super.initialize(attributes, options);
+    this.on('change:name change:svgstr', this.updateIcon);
+    this.updateIcon();
+  }
+
+  get labIcon(): LabIcon {
+    return this._labIcon;
+  }
+
+  /**
+   * Update the LabIcon when model chenges occur
+   */
+  updateIcon() {
+    const name = this.get('name');
+    const svgstr = this.get('svgstr');
+    if (!this._labIcon || this._labIcon.name !== name) {
+      this._labIcon = new LabIcon({ name, svgstr });
+    }
+    this._labIcon.svgstr = svgstr;
+    this.trigger('change');
+  }
+
+  protected _labIcon: LabIcon;
+
+  static model_name = 'IconModel';
+  static model_module = MODULE_NAME;
+  static model_module_version = MODULE_VERSION;
+  static view_name = 'IconView';
+  static view_module = MODULE_NAME;
+  static view_module_version = MODULE_VERSION;
+}

--- a/src/widgets/shell.ts
+++ b/src/widgets/shell.ts
@@ -82,14 +82,16 @@ export class ShellModel extends WidgetModel {
       }
     );
 
-    const updateTitle = (): void => {
+    const updateTitle = async (): Promise<void> => {
+      const icon = await unpack_models(title.get('icon'), this.widget_manager);
       luminoWidget.title.label = title.get('label');
-      luminoWidget.title.iconClass = title.get('icon_class');
+      luminoWidget.title.iconClass = icon ? null : title.get('icon_class');
+      luminoWidget.title.icon = icon ? icon.labIcon : null;
       luminoWidget.title.closable = title.get('closable');
     };
 
     title.on('change', updateTitle);
-    updateTitle();
+    void updateTitle();
 
     if ((area === 'left' || area === 'right') && this._labShell) {
       let handler;

--- a/src/widgets/title.ts
+++ b/src/widgets/title.ts
@@ -1,7 +1,7 @@
 // Copyright (c) ipylab contributors
 // Distributed under the terms of the Modified BSD License.
 
-import { WidgetModel } from '@jupyter-widgets/base';
+import { WidgetModel, unpack_models } from '@jupyter-widgets/base';
 
 import { MODULE_NAME, MODULE_VERSION } from '../version';
 
@@ -19,6 +19,27 @@ export class TitleModel extends WidgetModel {
       _model_module: TitleModel.model_module,
       _model_module_version: TitleModel.model_module_version,
     };
+  }
+
+  /**
+   * Initialize a LabIcon instance.
+   *
+   * @param attributes The base attributes.
+   * @param options The initialization options.
+   */
+  initialize(attributes: any, options: any): void {
+    super.initialize(attributes, options);
+    this.on('change:icon', this.iconChanged);
+  }
+
+  /**
+   * Pass on changes from the icon.
+   */
+  async iconChanged() {
+    const icon = await unpack_models(this.get('icon'), this.widget_manager);
+    if (icon) {
+      icon.on('change', () => this.trigger('change'));
+    }
   }
 
   static model_name = 'TitleModel';


### PR DESCRIPTION
Thanks for `ipylab`!

Changes:
- [x] adds a new `Icon` which takes an `svgstr`
  - [x] can be given to both `Panel.title` and `add_command(icon=`).
  - [x] inherits from `DOMWidget` with an actual View so that it can be used out of these contexts as well... 
    - [x] it is a little funky because of how it expects to work inside `react`, but is fast _enough_
  - [x] adds a notebook with some links from other notebooks
- [x] improves the `jlpm watch` command to also build the labextension
- [x] delays loading the widgets implementations and dependencies until they are requested

Open questions:
- would it be better to call it `LabIcon` for searchability?
- what to do about closable sidebars?
  -  the `x` icon "wins"