### PR TITLE
Add rest of Title API

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Base Setup
       uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
     - name: Install JupyterLab
-      run: python -m pip install jupyterlab
+      run: python -m pip install jupyterlab >=3.1,<4
     - name: Lint TypeScript
       run: |
         jlpm

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Base Setup
       uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
     - name: Install JupyterLab
-      run: python -m pip install jupyterlab >=3.1,<4
+      run: python -m pip install 'jupyterlab >=3.1,<4'
     - name: Lint TypeScript
       run: |
         jlpm

--- a/examples/icons.ipynb
+++ b/examples/icons.ipynb
@@ -149,8 +149,57 @@
     "app = JupyterFrontEnd()\n",
     "panel = Panel([icon_controls])\n",
     "panel.title.icon = icon\n",
+    "panel.title.closable = False\n",
     "dlink((background, \"value\"), (panel.title, \"label\"))\n",
     "app.shell.add(panel, \"main\", {\"mode\": \"split-right\"})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1df9a22e-90d6-440a-9921-3519e0e4da53",
+   "metadata": {},
+   "source": [
+    "### More Title Options\n",
+    "\n",
+    "Titles can also include a number of other options."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ebb3698f-7752-4584-89f1-7d552264a04e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from ipywidgets import Text, Checkbox\n",
+    "import json\n",
+    "\n",
+    "def noop(value):\n",
+    "    return value\n",
+    "\n",
+    "def as_json(value):\n",
+    "    try:\n",
+    "        return json.loads(value)\n",
+    "    except:\n",
+    "        return {}\n",
+    "\n",
+    "\n",
+    "title_controls = []\n",
+    "for field_name in [\"label\", \"caption\", \"mnemonic\", \"icon_class\", \"class_name\", \"dataset\"]:\n",
+    "    link_fn = noop\n",
+    "    placeholder = \"\"\n",
+    "    if field_name == \"dataset\":\n",
+    "        placeholder = \"{}\" \n",
+    "        link_fn = as_json\n",
+    "    field = Text(description=field_name, placeholder=placeholder)\n",
+    "    dlink((field, \"value\"), (panel.title, field_name), link_fn)\n",
+    "    title_controls.append(field)\n",
+    "closable = Checkbox(description=\"closable?\")\n",
+    "dlink((closable, \"value\"), (panel.title, \"closable\"))\n",
+    "title_controls.append(closable)\n",
+    "panel.children = [icon_controls, *title_controls]"
    ]
   },
   {

--- a/examples/icons.ipynb
+++ b/examples/icons.ipynb
@@ -173,7 +173,7 @@
    },
    "outputs": [],
    "source": [
-    "from ipywidgets import Text, Checkbox\n",
+    "from ipywidgets import Text, Checkbox, IntText\n",
     "import json\n",
     "\n",
     "def noop(value):\n",
@@ -187,7 +187,7 @@
     "\n",
     "\n",
     "title_controls = []\n",
-    "for field_name in [\"label\", \"caption\", \"mnemonic\", \"icon_class\", \"class_name\", \"dataset\"]:\n",
+    "for field_name in [\"label\", \"caption\", \"icon_class\", \"class_name\", \"dataset\"]:\n",
     "    link_fn = noop\n",
     "    placeholder = \"\"\n",
     "    if field_name == \"dataset\":\n",
@@ -198,7 +198,7 @@
     "    title_controls.append(field)\n",
     "closable = Checkbox(description=\"closable?\")\n",
     "dlink((closable, \"value\"), (panel.title, \"closable\"))\n",
-    "title_controls.append(closable)\n",
+    "title_controls += [closable]\n",
     "panel.children = [icon_controls, *title_controls]"
    ]
   },

--- a/ipylab/widgets.py
+++ b/ipylab/widgets.py
@@ -2,7 +2,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 from ipywidgets import VBox, Widget, register, widget_serialization
-from traitlets import Bool, Instance, Unicode
+from traitlets import Bool, Dict, Instance, Unicode
 from ._frontend import module_name, module_version
 from .icon import Icon
 
@@ -15,7 +15,13 @@ class Title(Widget):
 
     label = Unicode().tag(sync=True)
     icon_class = Unicode().tag(sync=True)
+    caption = Unicode().tag(sync=True)
+    class_name = Unicode().tag(sync=True)
     closable = Bool(True).tag(sync=True)
+    dataset = Dict().tag(sync=True)
+    icon_label = Unicode().tag(sync=True)
+    mnemonic = Unicode().tag(sync=True)
+
     icon = Instance(Icon, allow_none=True).tag(sync=True, **widget_serialization)
 
 

--- a/ipylab/widgets.py
+++ b/ipylab/widgets.py
@@ -20,7 +20,6 @@ class Title(Widget):
     closable = Bool(True).tag(sync=True)
     dataset = Dict().tag(sync=True)
     icon_label = Unicode().tag(sync=True)
-    mnemonic = Unicode().tag(sync=True)
 
     icon = Instance(Icon, allow_none=True).tag(sync=True, **widget_serialization)
 

--- a/src/widgets/shell.ts
+++ b/src/widgets/shell.ts
@@ -88,7 +88,6 @@ export class ShellModel extends WidgetModel {
       luminoWidget.title.closable = title.get('closable');
       luminoWidget.title.label = title.get('label');
       luminoWidget.title.dataset = title.get('dataset');
-      luminoWidget.title.mnemonic = title.get('mnemonic');
       luminoWidget.title.iconLabel = title.get('icon_label');
 
       const icon = await unpack_models(title.get('icon'), this.widget_manager);

--- a/src/widgets/shell.ts
+++ b/src/widgets/shell.ts
@@ -83,11 +83,17 @@ export class ShellModel extends WidgetModel {
     );
 
     const updateTitle = async (): Promise<void> => {
-      const icon = await unpack_models(title.get('icon'), this.widget_manager);
-      luminoWidget.title.label = title.get('label');
-      luminoWidget.title.iconClass = icon ? null : title.get('icon_class');
-      luminoWidget.title.icon = icon ? icon.labIcon : null;
+      luminoWidget.title.caption = title.get('caption');
+      luminoWidget.title.className = title.get('class_name');
       luminoWidget.title.closable = title.get('closable');
+      luminoWidget.title.label = title.get('label');
+      luminoWidget.title.dataset = title.get('dataset');
+      luminoWidget.title.mnemonic = title.get('mnemonic');
+      luminoWidget.title.iconLabel = title.get('icon_label');
+
+      const icon = await unpack_models(title.get('icon'), this.widget_manager);
+      luminoWidget.title.icon = icon ? icon.labIcon : null;
+      luminoWidget.title.iconClass = icon ? null : title.get('icon_class');
     };
 
     title.on('change', updateTitle);


### PR DESCRIPTION
## References

- fixes #124

## Code Changes
- [x] add `caption`, `class_name`, `dataset`, `icon_label`
  - > not `mnemonic`, didn't seem to do anything 
- [x] add to `icons` example notebook
- [x] run lint against jupyterlab 3

## User-facing Changes

A user can now customize a `Panel`'s title appearance more substantially

![image](https://github.com/jtpio/ipylab/assets/45380/7ac157e4-718d-4f0c-aa7c-610113c9ab3b)
