### PR TITLE
Bump JupyterLite dependencies

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -10,9 +10,9 @@ dependencies:
 - myst-parser
 - ipywidgets >=8.0,<9
 - jupyterlab >=4,<5
-- jupyterlite-core >=0.1.1,<0.2.0
-- jupyterlite-pyodide-kernel >=0.1.0,<0.2.0
-- jupyterlite-sphinx >=0.9.1,<0.10.0
-- nodejs=18
+- jupyterlite-core >=0.6.1,<0.7.0
+- jupyterlite-pyodide-kernel >=0.6.0,<0.7.0
+- jupyterlite-sphinx >=0.20.2,<0.21.0
+- nodejs=22
 - pip:
   - ..


### PR DESCRIPTION
The demo was still using a very old version.