### PR TITLE
Update minimum build jupyterlab

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling>=1.5.0", "jupyterlab>=4.0.0,<5", "hatch-nodejs-version"]
+requires = ["hatchling>=1.5.0", "jupyterlab>=4.1.0,<5", "hatch-nodejs-version"]
 build-backend = "hatchling.build"
 
 [project]
@@ -68,7 +68,7 @@ version_cmd = "hatch version"
 
 [tool.jupyter-releaser.hooks]
 before-build-npm = [
-    "python -m pip install 'jupyterlab>=4.0.0,<5'",
+    "python -m pip install 'jupyterlab>=4.1.0,<5'",
     "jlpm",
     "jlpm build:prod"
 ]


### PR DESCRIPTION
Thanks for `ipylab`!

This updates the minimum `jupyterlab` supported by the current version.

Noted on https://github.com/conda-forge/ipylab-feedstock/pull/22

Using an older version yields:

```
 │ JupyterLab v4.0.0
 │ $SRC_DIR_run_env/share/jupyter/labextensions
 │         jupyterlab_pygments v0.3.0 enabled OK (python, jupyterlab_pygments)
 │         ipylab v1.1.0 enabled  X (python, ipylab)
 │         @jupyter-widgets/jupyterlab-manager v5.0.15 enabled OK (python, jupyterlab_widgets)
 │ "ipylab@1.1.0" is not compatible with the current JupyterLab
 │ Conflicting Dependencies:
 │ JupyterLab              Extension      Package
 │ >=4.0.0 <4.1.0          >=4.1.0 <5.0.0 @jupyterlab/application
 │ >=4.0.0 <4.1.0          >=4.1.0 <5.0.0 @jupyterlab/apputils
 │ >=4.0.0 <4.1.0          >=4.1.0 <5.0.0 @jupyterlab/mainmenu
 │ >=4.0.0 <4.1.0          >=4.1.0 <5.0.0 @jupyterlab/notebook
```